### PR TITLE
Fixed infinite loop problem in IConnectionChannelPool.Rent() method when its disposed

### DIFF
--- a/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
+++ b/src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs
@@ -22,6 +22,7 @@ public class ConnectionChannelPool : IConnectionChannelPool, IDisposable
     private readonly ILogger<ConnectionChannelPool> _logger;
     private readonly ConcurrentQueue<IModel> _pool;
     private IConnection? _connection;
+    private bool _isDisposed;
 
     private int _count;
     private int _maxSize;
@@ -34,6 +35,7 @@ public class ConnectionChannelPool : IConnectionChannelPool, IDisposable
         _logger = logger;
         _maxSize = DefaultPoolSize;
         _pool = new ConcurrentQueue<IModel>();
+        _isDisposed = false;
 
         var capOptions = capOptionsAccessor.Value;
         var options = optionsAccessor.Value;
@@ -52,7 +54,7 @@ public class ConnectionChannelPool : IConnectionChannelPool, IDisposable
     {
         lock (SLock)
         {
-            while (_count > _maxSize)
+            while (_count > _maxSize && _isDisposed == false)
             {
                 Thread.SpinWait(1);
             }
@@ -91,6 +93,7 @@ public class ConnectionChannelPool : IConnectionChannelPool, IDisposable
             channel.Dispose();
         }
 
+        _isDisposed = true;
         _connection?.Dispose();
     }
 


### PR DESCRIPTION
### Description:
When using the IConnectionChannelPool.Rent() method, when a large number of operations are performed with parallel threads, a message is canceled immediately after being published, but the IConnectionChannelPool.Rent method cannot process this information yet. The value of the _maxSize variable becomes 0 and the loop becomes infinite.

#### Issue(s) addressed:
- None

#### Changes:
- IConnectionChannelPool.Rent() method updated and new property inserted to ConnectionChannelPool class with named liked _isDisposed

#### Affected components:
- src/DotNetCore.CAP.RabbitMQ/IConnectionChannelPool.Default.cs

#### How to test:
_You should create a minimum of 1000 different parallel threads at the same time and constantly sends intense requests. Cancel the requested cancellation times after some time. Then the _maxSize variable of the intensive processor processor will be set to 0 and the infinite loop will occur.

### Additional notes (optional):
_Provide any additional notes or context that may be relevant to the changes._

### Checklist:
- [x ] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the relevant tests (if applicable)
- [ x] My changes follow the project's code style guidelines

### Reviewers:
- Sorry I don't know anyone :/